### PR TITLE
Fix for duplicated window control buttons

### DIFF
--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -172,3 +172,6 @@
     cursor: pointer;
     display: -moz-box !important;
 }
+/* Remove duplicated window control buttons*/ 
+#nav-bar .titlebar-buttonbox{display: none !important
+}

--- a/userChrome.css
+++ b/userChrome.css
@@ -172,3 +172,6 @@
     cursor: pointer;
     display: -moz-box !important;
 }
+/* Remove duplicated window control buttons*/ 
+#nav-bar .titlebar-buttonbox{display: none !important
+}


### PR DESCRIPTION
Installed this userchrome on my Arch Linux system and noted that it had a duplicated set of window control buttons. Added a bit to remove one set and return the look to normal.